### PR TITLE
Avoid crash if ws is nil

### DIFF
--- a/web/app/websocket.go
+++ b/web/app/websocket.go
@@ -56,8 +56,10 @@ func WebSocketHandler(w http.ResponseWriter, r *http.Request) {
 func WsClientSend(token string, message []byte) {
 	for k, v := range wsConn.clientmapping {
 		if k == token {
-			v.WriteMessage(1, message)
-			log.Println("sending..")
+			if v != nil {
+				v.WriteMessage(1, message)
+				log.Println("sending..")
+			}
 		}
 	}
 }


### PR DESCRIPTION
If WS is nil, app crashes.
WS can be nil if connection cannot be made by, IE, CORS issues.

Signed-off-by: chencho <smunoz@cavium.com>