### PR TITLE
Device service returns status 200 with empty content as fails

### DIFF
--- a/web/static/js/pages/devices/device.js
+++ b/web/static/js/pages/devices/device.js
@@ -260,6 +260,7 @@ var deviceModuleBtnGroup = {
 					type:'PUT',
 					contentType:'application/json',
 					data:JSON.stringify(paramBody),
+					dataType: "text",
 					success:function(data){
 						$('#device_detail #command_list tbody input[name="reading_value'+command.id+'"]').val("success");
 						$('#'+command.id+'').prop('disabled',false);


### PR DESCRIPTION
If device service returns status 200 with empty body and a JSON Content-Type then it fails and we have to rely on dataType: 'text'. (If users using JQuery > 1.9)